### PR TITLE
fix: missing bin install in brew formula

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 .DS_Store
 
 .idea/
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,3 +31,4 @@ brews:
     license: "MIT"
     install: |
       man1.install "#{buildpath}/share/man/abc.1"
+      bin.install "despell"


### PR DESCRIPTION
as of now, the formula installs the man pages only... this should fix it...