### PR TITLE
fix: go mod name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module despell
+module github.com/bensadeh/despell
 
 go 1.17

--- a/main.go
+++ b/main.go
@@ -1,12 +1,13 @@
 package main
 
 import (
-	"despell/arguments"
-	"despell/core"
-	"despell/overrider"
-	"despell/stock"
-	"despell/unknown"
 	"fmt"
+
+	"github.com/bensadeh/despell/arguments"
+	"github.com/bensadeh/despell/core"
+	"github.com/bensadeh/despell/overrider"
+	"github.com/bensadeh/despell/stock"
+	"github.com/bensadeh/despell/unknown"
 )
 
 func main() {

--- a/overrider/overrider.go
+++ b/overrider/overrider.go
@@ -1,11 +1,12 @@
 package overrider
 
 import (
-	"despell/core"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path"
+
+	"github.com/bensadeh/despell/core"
 )
 
 func GetOverrides() map[string]core.Icon {

--- a/stock/stock.go
+++ b/stock/stock.go
@@ -1,9 +1,9 @@
 package stock
 
 import (
-	"despell/colors"
-	"despell/core"
-	"despell/icons"
+	"github.com/bensadeh/despell/colors"
+	"github.com/bensadeh/despell/core"
+	"github.com/bensadeh/despell/icons"
 )
 
 func GetDefaults() map[string]core.Icon {

--- a/unknown/unknown.go
+++ b/unknown/unknown.go
@@ -1,6 +1,6 @@
 package unknown
 
-import "despell/core"
+import "github.com/bensadeh/despell/core"
 
 const (
 	UnknownCommandKey = "unknownCommand"


### PR DESCRIPTION
otherwise its not possible to install it with `go install`:

```
❯ go install github.com/bensadeh/despell@latest
go: downloading github.com/bensadeh/despell v0.0.0-20220720060347-06252f65d509
go: github.com/bensadeh/despell@latest: github.com/bensadeh/despell@v0.0.0-20220720060347-06252f65d509: parsing go.mod:
        module declares its path as: despell
                but was required as: github.com/bensadeh/despell
```